### PR TITLE
Remove commented-out boilerplate

### DIFF
--- a/CRM/Grassrootspetition/BAO/GrassrootsPetitionCampaign.php
+++ b/CRM/Grassrootspetition/BAO/GrassrootsPetitionCampaign.php
@@ -3,24 +3,5 @@ use CRM_Grassrootspetition_ExtensionUtil as E;
 
 class CRM_Grassrootspetition_BAO_GrassrootsPetitionCampaign extends CRM_Grassrootspetition_DAO_GrassrootsPetitionCampaign {
 
-  /**
-   * Create a new GrassrootsPetitionCampaign based on array-data
-   *
-   * @param array $params key-value pairs
-   * @return CRM_Grassrootspetition_DAO_GrassrootsPetitionCampaign|NULL
-   *
-  public static function create($params) {
-    $className = 'CRM_Grassrootspetition_DAO_GrassrootsPetitionCampaign';
-    $entityName = 'GrassrootsPetitionCampaign';
-    $hook = empty($params['id']) ? 'create' : 'edit';
-
-    CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
-    $instance = new $className();
-    $instance->copyValues($params);
-    $instance->save();
-    CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
-
-    return $instance;
-  } */
 
 }


### PR DESCRIPTION
Civix used to generate commented-out BAO create functions, however all BAOs now inherit writeRecords() from their parent.

Since this function was never uncommented, it's safe to remove.